### PR TITLE
Use freshly created BytesIO streams for each time a stream is needed

### DIFF
--- a/image_analysis_api/services/image_analysis_service.py
+++ b/image_analysis_api/services/image_analysis_service.py
@@ -13,14 +13,14 @@ class ImageAnalysisService:
         self.api_key = api_key
 
     def detect_objects(
-        self, image_data: BytesIO, acceptable_confidence_score: Decimal
+        self, image_data: bytes, acceptable_confidence_score: Decimal
     ) -> List[str]:
         computervision_client = ComputerVisionClient(
             endpoint=self.endpoint,
             credentials=CognitiveServicesCredentials(self.api_key),
         )
         analysis_response = computervision_client.analyze_image_in_stream(
-            image_data, [VisualFeatureTypes.objects]
+            BytesIO(image_data), [VisualFeatureTypes.objects]
         )
 
         objects = [

--- a/image_analysis_api/services/image_storage_service.py
+++ b/image_analysis_api/services/image_storage_service.py
@@ -6,12 +6,12 @@ class ImageStorageService:
     def __init__(self, connection_string: str) -> None:
         self.connection_string = connection_string
 
-    def upload_image(self, image_name: str, image_data: BytesIO) -> str:
+    def upload_image(self, image_name: str, image_data: bytes) -> str:
         blob_service_client = BlobServiceClient.from_connection_string(
             self.connection_string
         )
         blob_client: BlobClient = blob_service_client.get_blob_client(
             container="images", blob=image_name
         )
-        blob_client.upload_blob(image_data)
+        blob_client.upload_blob(BytesIO(image_data))
         return blob_client.url


### PR DESCRIPTION
 A stream cannot be read multiple times without some manipulation. To keep things simple, we now create a new stream from the source bytes as needed.